### PR TITLE
fix(ens):FDS Registrar

### DIFF
--- a/contracts/FDSRegistrar.sol
+++ b/contracts/FDSRegistrar.sol
@@ -1,156 +1,22 @@
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import "@ensdomains/ens-contracts/contracts/ethregistrar/BaseRegistrar.sol";
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@ensdomains/ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol";
 
-contract FDSRegistrar is ERC721, BaseRegistrar  {
-    bytes32 constant ZERO_HASH = 0x0000000000000000000000000000000000000000000000000000000000000000;
-  
-    // from specification https://eips.ethereum.org/EIPS/eip-137
-    bytes32 constant NAME_HASH = keccak256(abi.encodePacked(ZERO_HASH, keccak256(abi.encodePacked("fds"))));
-    // 0x854683790d7d8c6e4d741a8a5f01dc2952c51f38407545ea5117889dc81bd141;
+/**
+ * The ENS registry contract.
+ */
+contract FDSRegistrar is BaseRegistrarImplementation {
+  bytes32 constant ZERO_HASH = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
-    // A map of expiry times
-    mapping(uint256=>uint) expiries;
+  // from specification https://eips.ethereum.org/EIPS/eip-137
+  bytes32 constant NAME_HASH = keccak256(abi.encodePacked(ZERO_HASH, keccak256(abi.encodePacked("fds"))));
+  // 0x854683790d7d8c6e4d741a8a5f01dc2952c51f38407545ea5117889dc81bd141;
 
-    bytes4 constant private INTERFACE_META_ID = bytes4(keccak256("supportsInterface(bytes4)"));
-    bytes4 constant private ERC721_ID = bytes4(
-        keccak256("balanceOf(address)") ^
-        keccak256("ownerOf(uint256)") ^
-        keccak256("approve(address,uint256)") ^
-        keccak256("getApproved(uint256)") ^
-        keccak256("setApprovalForAll(address,bool)") ^
-        keccak256("isApprovedForAll(address,address)") ^
-        keccak256("transferFrom(address,address,uint256)") ^
-        keccak256("safeTransferFrom(address,address,uint256)") ^
-        keccak256("safeTransferFrom(address,address,uint256,bytes)")
-    );
-    bytes4 constant private RECLAIM_ID = bytes4(keccak256("reclaim(uint256,address)"));
-
-    /**
-     * v2.1.3 version of _isApprovedOrOwner which calls ownerOf(tokenId) and takes grace period into consideration instead of ERC721.ownerOf(tokenId);
-     * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v2.1.3/contracts/token/ERC721/ERC721.sol#L187
-     * @dev Returns whether the given spender can transfer a given token ID
-     * @param spender address of the spender to query
-     * @param tokenId uint256 ID of the token to be transferred
-     * @return bool whether the msg.sender is approved for the given token ID,
-     *    is an operator of the owner, or is the owner of the token
-     */
-    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view override returns (bool) {
-        address owner = ownerOf(tokenId);
-        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
-    }
-
-    constructor(ENS _ens) ERC721("","") {
-        ens = _ens;
-        baseNode = NAME_HASH;
-    }
-
-    modifier live {
-        _;
-    }
-
-    /**
-     * @dev Gets the owner of the specified token ID. Names become unowned
-     *      when their registration expires.
-     * @param tokenId uint256 ID of the token to query the owner of
-     * @return address currently marked as the owner of the given token ID
-     */
-    function ownerOf(uint256 tokenId) public view override(IERC721, ERC721) returns (address) {
-        require(expiries[tokenId] > block.timestamp);
-        return super.ownerOf(tokenId);
-    }
-
-    // Authorises a controller, who can register and renew domains.
-    function addController(address controller) external override onlyOwner {
-        controllers[controller] = true;
-        emit ControllerAdded(controller);
-    }
-
-    // Revoke controller permission for an address.
-    function removeController(address controller) external override onlyOwner {
-        controllers[controller] = false;
-        emit ControllerRemoved(controller);
-    }
-
-    // Set the resolver for the TLD this registrar manages.
-    function setResolver(address resolver) external override onlyOwner {
-        ens.setResolver(baseNode, resolver);
-    }
-
-    // Returns the expiration timestamp of the specified id.
-    function nameExpires(uint256 id) external view override returns(uint) {
-        return expiries[id];
-    }
-
-    // Returns true iff the specified name is available for registration.
-    function available(uint256 id) public view override returns(bool) {
-        // Not available if it's registered here or in its grace period.
-        return expiries[id] + GRACE_PERIOD < block.timestamp;
-    }
-
-    /**
-     * @dev Register a name.
-     * @param id The token ID (keccak256 of the label).
-     * @param owner The address that should own the registration.
-     * @param duration Duration in seconds for the registration.
-     */
-    function register(uint256 id, address owner, uint duration) external override returns(uint) {
-      return _register(id, owner, duration, true);
-    }
-
-    /**
-     * @dev Register a name, without modifying the registry.
-     * @param id The token ID (keccak256 of the label).
-     * @param owner The address that should own the registration.
-     * @param duration Duration in seconds for the registration.
-     */
-    function registerOnly(uint256 id, address owner, uint duration) external returns(uint) {
-      return _register(id, owner, duration, false);
-    }
-
-    function _register(uint256 id, address owner, uint duration, bool updateRegistry) internal returns(uint) {
-        // TODO: investigate why it causes gas estimate error
-        // require(available(id));
-        require(block.timestamp + duration + GRACE_PERIOD > block.timestamp + GRACE_PERIOD); // Prevent future overflow
-
-        expiries[id] = block.timestamp + duration;
-        if(_exists(id)) {
-            // Name was previously owned, and expired
-           _burn(id);
-        }
-        _mint(owner, id);
-        if(updateRegistry) {
-            ens.setSubnodeOwner(baseNode, bytes32(id), owner);
-        }
-
-        emit NameRegistered(id, owner, block.timestamp + duration);
-
-        return block.timestamp + duration;
-    }
-
-    function renew(uint256 id, uint duration) external override live returns(uint) {
-        require(expiries[id] + GRACE_PERIOD >= block.timestamp); // Name must be registered here or in grace period
-        require(expiries[id] + duration + GRACE_PERIOD > duration + GRACE_PERIOD); // Prevent future overflow
-
-        expiries[id] += duration;
-        emit NameRenewed(id, expiries[id]);
-        return expiries[id];
-    }
-
-    /**
-     * @dev Reclaim ownership of a name in ENS, if you own it in the registrar.
-     */
-    function reclaim(uint256 id, address owner) external override live {
-        require(_isApprovedOrOwner(msg.sender, id));
-        ens.setSubnodeOwner(baseNode, bytes32(id), owner);
-    }
-
-    function supportsInterface(bytes4 interfaceID) public override(ERC721, IERC165) view returns (bool) {
-        return interfaceID == INTERFACE_META_ID ||
-               interfaceID == ERC721_ID ||
-               interfaceID == RECLAIM_ID;
-    }
+  /**
+   * @dev Constructs a new ENS registrar.
+   */
+  constructor(ENS _registry) 
+    BaseRegistrarImplementation(_registry, NAME_HASH) {
+  }
 }

--- a/js-library/src/services/ens.ts
+++ b/js-library/src/services/ens.ts
@@ -121,6 +121,11 @@ export class ENS {
       }
 
       if (ownerAddress === NULL_ADDRESS) {
+        // Per ENS team recommendation, add user as controller
+        await waitTransaction(
+          this._fdsRegistrarContract.addController(ownerAddress),
+        )
+
         await waitTransaction(
           this._fdsRegistrarContract.register(keccak256(toUtf8Bytes(username)), address, expires),
         )

--- a/test/FDSRegistrar.ts
+++ b/test/FDSRegistrar.ts
@@ -29,12 +29,15 @@ describe('FDSRegistrar', () => {
     controllerAccount = signers[1]
     registrantAccount = signers[2]
     otherAccount = signers[3]
-    const ENS = await ethers.getContractFactory('ENSRegistry')
+    const ENS = await ethers.getContractFactory(
+      '@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol:ENSRegistry',
+    )
+    // @ts-ignore
     ens = await ENS.deploy()
     await ens.deployed()
     const FDSRegistrar = await ethers.getContractFactory('FDSRegistrar')
     registrar = await FDSRegistrar.deploy(ens.address)
-    await registrar.addController(controllerAccount.address)
+    // Do not add controller account, use registrar account instead inside each test
     await ens.setSubnodeOwner(ZERO_HASH, keccak256FromUtf8Bytes('fds'), registrar.address)
 
     const publicResolver = await ethers.getContractFactory('PublicResolver')
@@ -45,9 +48,17 @@ describe('FDSRegistrar', () => {
     await registrar.setResolver(resolver.address)
   })
 
+  beforeEach(async () => {
+    await registrar.addController(registrantAccount.address)
+  })
+
+  afterEach(async () => {
+    await registrar.removeController(registrantAccount.address)
+  })
+
   it('should allow new registrations', async () => {
-    const controllerAccountReg = registrar.connect(controllerAccount)
-    await controllerAccountReg.register(keccak256FromUtf8Bytes('newname'), registrantAccount.address, 86400)
+    const selfRegistration = registrar.connect(registrantAccount)
+    await selfRegistration.register(keccak256FromUtf8Bytes('newname'), registrantAccount.address, 86400)
 
     const block = await ethers.provider.getBlock('latest')
     expect(await ens.owner(ethers.utils.namehash('newname.fds'))).equal(registrantAccount.address)
@@ -56,8 +67,8 @@ describe('FDSRegistrar', () => {
   })
 
   it('should allow registrations without updating the registry', async () => {
-    const controllerAccountReg = registrar.connect(controllerAccount)
-    await controllerAccountReg.registerOnly(keccak256FromUtf8Bytes('silentname'), registrantAccount.address, 86400)
+    const selfRegistration = registrar.connect(registrantAccount)
+    await selfRegistration.registerOnly(keccak256FromUtf8Bytes('silentname'), registrantAccount.address, 86400)
     const block = await ethers.provider.getBlock('latest')
     expect(await ens.owner(ethers.utils.namehash('silentname.fds'))).equal(ZERO_ADDRESS)
     expect(await registrar.ownerOf(keccak256FromUtf8Bytes('silentname'))).equal(registrantAccount.address)
@@ -67,26 +78,34 @@ describe('FDSRegistrar', () => {
   })
 
   it('should allow renewals', async () => {
-    const controllerAccountReg = registrar.connect(controllerAccount)
+    const selfRegistration = registrar.connect(registrantAccount)
     const oldExpires = await registrar.nameExpires(keccak256FromUtf8Bytes('newname'))
-    await controllerAccountReg.renew(keccak256FromUtf8Bytes('newname'), 86400)
+    await selfRegistration.renew(keccak256FromUtf8Bytes('newname'), 86400)
     expect((await registrar.nameExpires(keccak256FromUtf8Bytes('newname'))).toNumber()).equal(
       oldExpires.add(86400).toNumber(),
     )
   })
 
-  it('should allow new account to register', async () => {
+  it('should only allow the controller to register', async () => {
     const otherAccountReg = registrar.connect(otherAccount)
 
-    await otherAccountReg.register(keccak256FromUtf8Bytes('foo'), otherAccount.address, 86400, {
-      from: otherAccount.address,
-    })
+    try {
+      await otherAccountReg.register(keccak256FromUtf8Bytes('foo'), otherAccount.address, 86400, {
+        from: otherAccount.address,
+      })
+    } catch (e: any) {
+      expect(e.message).contain('Transaction reverted')
+    }
   })
 
-  it('should allow new account to renew', async () => {
+  it('should only allow the controller to renew', async () => {
     const otherAccountReg = registrar.connect(otherAccount)
 
-    await otherAccountReg.renew(keccak256FromUtf8Bytes('newname'), 86400, { from: otherAccount.address })
+    try {
+      await otherAccountReg.renew(keccak256FromUtf8Bytes('newname'), 86400, { from: otherAccount.address })
+    } catch (e: any) {
+      expect(e.message).contain('Transaction reverted')
+    }
   })
 
   it('should not permit registration of already registered names', async () => {
@@ -191,8 +210,8 @@ describe('FDSRegistrar', () => {
   })
 
   it('should allow renewal during the grace period', async () => {
-    const controllerAccountReg = registrar.connect(controllerAccount)
-    await controllerAccountReg.renew(keccak256FromUtf8Bytes('newname'), 86400)
+    const selfRegistration = registrar.connect(registrantAccount)
+    await selfRegistration.renew(keccak256FromUtf8Bytes('newname'), 86400)
   })
 
   it('should allow registration of an expired domain', async () => {
@@ -205,9 +224,9 @@ describe('FDSRegistrar', () => {
       await registrar.ownerOf(keccak256FromUtf8Bytes('newname'))
     } catch (error) {}
 
-    const controllerAccountReg = registrar.connect(controllerAccount)
-    await controllerAccountReg.register(keccak256FromUtf8Bytes('newname'), otherAccount.address, 86400, {
-      from: controllerAccount.address,
+    const selfRegistration = registrar.connect(registrantAccount)
+    await selfRegistration.register(keccak256FromUtf8Bytes('newname'), otherAccount.address, 86400, {
+      from: registrantAccount.address,
     })
     expect(await registrar.ownerOf(keccak256FromUtf8Bytes('newname')), otherAccount.address)
   })


### PR DESCRIPTION
 per ENS team support recommendation, user can be a controller. updated specs and previously rollbacked code