### PR TITLE
revert: #63

### DIFF
--- a/contracts/FDSRegistrar.sol
+++ b/contracts/FDSRegistrar.sol
@@ -1,22 +1,156 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
-import "@ensdomains/ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol";
+import "@ensdomains/ens-contracts/contracts/ethregistrar/BaseRegistrar.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-/**
- * The ENS registry contract.
- */
-contract FDSRegistrar is BaseRegistrarImplementation {
-  bytes32 constant ZERO_HASH = 0x0000000000000000000000000000000000000000000000000000000000000000;
+contract FDSRegistrar is ERC721, BaseRegistrar  {
+    bytes32 constant ZERO_HASH = 0x0000000000000000000000000000000000000000000000000000000000000000;
+  
+    // from specification https://eips.ethereum.org/EIPS/eip-137
+    bytes32 constant NAME_HASH = keccak256(abi.encodePacked(ZERO_HASH, keccak256(abi.encodePacked("fds"))));
+    // 0x854683790d7d8c6e4d741a8a5f01dc2952c51f38407545ea5117889dc81bd141;
 
-  // from specification https://eips.ethereum.org/EIPS/eip-137
-  bytes32 constant NAME_HASH = keccak256(abi.encodePacked(ZERO_HASH, keccak256(abi.encodePacked("fds"))));
-  // 0x854683790d7d8c6e4d741a8a5f01dc2952c51f38407545ea5117889dc81bd141;
+    // A map of expiry times
+    mapping(uint256=>uint) expiries;
 
-  /**
-   * @dev Constructs a new ENS registrar.
-   */
-  constructor(ENS _registry) 
-    BaseRegistrarImplementation(_registry, NAME_HASH) {
-  }
+    bytes4 constant private INTERFACE_META_ID = bytes4(keccak256("supportsInterface(bytes4)"));
+    bytes4 constant private ERC721_ID = bytes4(
+        keccak256("balanceOf(address)") ^
+        keccak256("ownerOf(uint256)") ^
+        keccak256("approve(address,uint256)") ^
+        keccak256("getApproved(uint256)") ^
+        keccak256("setApprovalForAll(address,bool)") ^
+        keccak256("isApprovedForAll(address,address)") ^
+        keccak256("transferFrom(address,address,uint256)") ^
+        keccak256("safeTransferFrom(address,address,uint256)") ^
+        keccak256("safeTransferFrom(address,address,uint256,bytes)")
+    );
+    bytes4 constant private RECLAIM_ID = bytes4(keccak256("reclaim(uint256,address)"));
+
+    /**
+     * v2.1.3 version of _isApprovedOrOwner which calls ownerOf(tokenId) and takes grace period into consideration instead of ERC721.ownerOf(tokenId);
+     * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v2.1.3/contracts/token/ERC721/ERC721.sol#L187
+     * @dev Returns whether the given spender can transfer a given token ID
+     * @param spender address of the spender to query
+     * @param tokenId uint256 ID of the token to be transferred
+     * @return bool whether the msg.sender is approved for the given token ID,
+     *    is an operator of the owner, or is the owner of the token
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view override returns (bool) {
+        address owner = ownerOf(tokenId);
+        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender));
+    }
+
+    constructor(ENS _ens) ERC721("","") {
+        ens = _ens;
+        baseNode = NAME_HASH;
+    }
+
+    modifier live {
+        _;
+    }
+
+    /**
+     * @dev Gets the owner of the specified token ID. Names become unowned
+     *      when their registration expires.
+     * @param tokenId uint256 ID of the token to query the owner of
+     * @return address currently marked as the owner of the given token ID
+     */
+    function ownerOf(uint256 tokenId) public view override(IERC721, ERC721) returns (address) {
+        require(expiries[tokenId] > block.timestamp);
+        return super.ownerOf(tokenId);
+    }
+
+    // Authorises a controller, who can register and renew domains.
+    function addController(address controller) external override onlyOwner {
+        controllers[controller] = true;
+        emit ControllerAdded(controller);
+    }
+
+    // Revoke controller permission for an address.
+    function removeController(address controller) external override onlyOwner {
+        controllers[controller] = false;
+        emit ControllerRemoved(controller);
+    }
+
+    // Set the resolver for the TLD this registrar manages.
+    function setResolver(address resolver) external override onlyOwner {
+        ens.setResolver(baseNode, resolver);
+    }
+
+    // Returns the expiration timestamp of the specified id.
+    function nameExpires(uint256 id) external view override returns(uint) {
+        return expiries[id];
+    }
+
+    // Returns true iff the specified name is available for registration.
+    function available(uint256 id) public view override returns(bool) {
+        // Not available if it's registered here or in its grace period.
+        return expiries[id] + GRACE_PERIOD < block.timestamp;
+    }
+
+    /**
+     * @dev Register a name.
+     * @param id The token ID (keccak256 of the label).
+     * @param owner The address that should own the registration.
+     * @param duration Duration in seconds for the registration.
+     */
+    function register(uint256 id, address owner, uint duration) external override returns(uint) {
+      return _register(id, owner, duration, true);
+    }
+
+    /**
+     * @dev Register a name, without modifying the registry.
+     * @param id The token ID (keccak256 of the label).
+     * @param owner The address that should own the registration.
+     * @param duration Duration in seconds for the registration.
+     */
+    function registerOnly(uint256 id, address owner, uint duration) external returns(uint) {
+      return _register(id, owner, duration, false);
+    }
+
+    function _register(uint256 id, address owner, uint duration, bool updateRegistry) internal returns(uint) {
+        // TODO: investigate why it causes gas estimate error
+        // require(available(id));
+        require(block.timestamp + duration + GRACE_PERIOD > block.timestamp + GRACE_PERIOD); // Prevent future overflow
+
+        expiries[id] = block.timestamp + duration;
+        if(_exists(id)) {
+            // Name was previously owned, and expired
+           _burn(id);
+        }
+        _mint(owner, id);
+        if(updateRegistry) {
+            ens.setSubnodeOwner(baseNode, bytes32(id), owner);
+        }
+
+        emit NameRegistered(id, owner, block.timestamp + duration);
+
+        return block.timestamp + duration;
+    }
+
+    function renew(uint256 id, uint duration) external override live returns(uint) {
+        require(expiries[id] + GRACE_PERIOD >= block.timestamp); // Name must be registered here or in grace period
+        require(expiries[id] + duration + GRACE_PERIOD > duration + GRACE_PERIOD); // Prevent future overflow
+
+        expiries[id] += duration;
+        emit NameRenewed(id, expiries[id]);
+        return expiries[id];
+    }
+
+    /**
+     * @dev Reclaim ownership of a name in ENS, if you own it in the registrar.
+     */
+    function reclaim(uint256 id, address owner) external override live {
+        require(_isApprovedOrOwner(msg.sender, id));
+        ens.setSubnodeOwner(baseNode, bytes32(id), owner);
+    }
+
+    function supportsInterface(bytes4 interfaceID) public override(ERC721, IERC165) view returns (bool) {
+        return interfaceID == INTERFACE_META_ID ||
+               interfaceID == ERC721_ID ||
+               interfaceID == RECLAIM_ID;
+    }
 }

--- a/js-library/src/services/ens.ts
+++ b/js-library/src/services/ens.ts
@@ -121,11 +121,6 @@ export class ENS {
       }
 
       if (ownerAddress === NULL_ADDRESS) {
-        // Per ENS team recommendation, add user as controller
-        await waitTransaction(
-          this._fdsRegistrarContract.addController(ownerAddress),
-        )
-
         await waitTransaction(
           this._fdsRegistrarContract.register(keccak256(toUtf8Bytes(username)), address, expires),
         )


### PR DESCRIPTION
This reverts commit 08c3eab91c446f9365325d12644b9583b2646a76 that has been merged from #63

The cause is the js-library test does not run successfully, namely the `✕ Register username with different wallet (1371 ms)` test case.